### PR TITLE
Update dnd.js

### DIFF
--- a/src/runtime/html5/dnd.js
+++ b/src/runtime/html5/dnd.js
@@ -109,7 +109,7 @@ define([
             me.dndOver = false;
             me.elem.removeClass( prefix + 'over' );
 
-            if ( data ) {
+            if ( !dataTransfer || data ) {
                 return;
             }
 


### PR DESCRIPTION
页面内拖拽，dataTransfer 可能为 undefined，这时候 _getTansferFiles 拿不到 items，会报 `Cannot read property 'items' of undefined` 的错误